### PR TITLE
Contruct goal marker on initialize

### DIFF
--- a/mav_planning_rviz/src/planning_panel.cpp
+++ b/mav_planning_rviz/src/planning_panel.cpp
@@ -38,12 +38,15 @@ PlanningPanel::PlanningPanel(QWidget* parent)
       node_(std::make_shared<rclcpp::Node>("mav_planning_rviz")),
       interactive_markers_(node_) {
   createLayout();
-  goal_marker_ = std::make_shared<GoalMarker>(node_);
-  planner_state_sub_ = node_->create_subscription<planner_msgs::msg::NavigationStatus>(
-      "/planner_status", 1, std::bind(&PlanningPanel::plannerstateCallback, this, _1));
 }
 
 void PlanningPanel::onInitialize() {
+  auto rviz_ros_node = this->getDisplayContext()->getRosNodeAbstraction().lock()->get_raw_node();
+  goal_marker_ = std::make_shared<GoalMarker>(rviz_ros_node);
+
+  planner_state_sub_ = rviz_ros_node->create_subscription<planner_msgs::msg::NavigationStatus>(
+      "/planner_status", 1, std::bind(&PlanningPanel::plannerstateCallback, this, _1));
+
   interactive_markers_.initialize();
   interactive_markers_.setPoseUpdatedCallback(std::bind(&PlanningPanel::updateInteractiveMarkerPose, this, _1));
 


### PR DESCRIPTION
**Problem Description**
This solves the problem of interactive markers not registering properly in rviz in https://github.com/ethz-asl/terrain-navigation/pull/27.

The solution is to use the Rviz node for interactive markers. 

Reference: https://www.reddit.com/r/ROS/comments/13wnmw1/subscription_in_custom_rviz2_panel_plugin/ 